### PR TITLE
fix description. It shouldn't be over 140 characters

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery.dynatree",
-  "description": "Dynatree is a JavaScript dynamic tree view plugin for jQuery with support for persistence, keyboard, checkboxes, drag'n'drop, and lazy loading.",
+  "description": "A JavaScript dynamic tree view plugin for jQuery with support for persistence, keyboard, checkboxes, drag'n'drop and lazy loading.",
   "main": [
     "dist/jquery.dynatree.js"
   ],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jquery.dynatree",
   "title": "jQuery Dynatree Plugin",
-  "description": "Dynatree is a JavaScript dynamic tree view plugin for jQuery with support for persistence, keyboard, checkboxes, drag'n'drop, and lazy loading.",
+  "description": "A JavaScript dynamic tree view plugin for jQuery with support for persistence, keyboard, checkboxes, drag'n'drop and lazy loading.",
   "version": "1.2.8-0",
   "homepage": "https://github.com/mar10/dynatree/",
   "author": {


### PR DESCRIPTION
> bower dynatree#1.2.7          EINVALID Failed to read /var/folders/1t/y1l91wl10c1dzz3682wqvnxh0000gn/T/moi/bower/dynatree-58906-Oy3Dwq/bower.json

> Additional error details:
> The description is too long. 140 characters should be more than enough

https://github.com/bower/bower.json-spec#description