### PR TITLE
Cleanup Destroy Events

### DIFF
--- a/src/jquery.dynatree.js
+++ b/src/jquery.dynatree.js
@@ -2974,6 +2974,11 @@ $.widget("ui.dynatree", {
 		this.tree._load();
 		this.tree.logDebug("Dynatree._init(): done.");
 	},
+	
+	_destroy: function(){
+		this.unbind();
+		this.tree.logDebug("Dynatree._destroy(): done.");
+	},
 
 	bind: function() {
 		// Prevent duplicate binding
@@ -3030,12 +3035,8 @@ $.widget("ui.dynatree", {
 		}
 		var div = this.tree.divTree;
 
-		if( div.addEventListener ) {
-			div.addEventListener("focus", __focusHandler, true);
-			div.addEventListener("blur", __focusHandler, true);
-		} else {
-			div.onfocusin = div.onfocusout = __focusHandler;
-		}
+		this.element.bind("focusin.dynatree focusout.dynatree", __focusHandler);
+		
 		// EVENTS
 		// disable click if event is configured to something else
 //      if (!(/^click/).test(o.event))


### PR DESCRIPTION
Added a destroy method so that events are unbound when the widget is removed from the page. Also changed focus binding so that namespaces are respected to prevent leaking events on rebind/destroy. I am not sure if this is the correct way to handle the focus events but I feel it respected the intent of the original code.
